### PR TITLE
initial sketch of `namectl` utility

### DIFF
--- a/namectl.go
+++ b/namectl.go
@@ -1,0 +1,137 @@
+package main
+
+//
+// A rough sketch of a namerd controller utility.
+//
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/buoyantio/namectl/namerd"
+	// TODO "github.com/spf13/cobra"
+)
+
+var usageOverview = `namectl controls the namerd rpc route management service.
+
+Usage:
+  namectl [flags]
+  namectl [command]
+
+Available Commands:
+  list		List all Dtab names.
+  get		Get a Dtab by name.
+  new		Create a new Dtab.
+  update	Update an existing Dtab.
+`
+
+func exUsage(msg string) {
+	fmt.Fprint(os.Stderr, usageOverview)
+	fmt.Fprintf(os.Stderr, "\nerror: %s\n", msg)
+	os.Exit(64)
+}
+
+func main() {
+	baseURLStr := flag.String("base-url", os.Getenv("NAMECTL_BASE_URL"),
+		"base url to reach namerd's ctl api")
+	flag.Parse()
+
+	args := flag.Args()
+	if len(args) == 0 {
+		exUsage("command required")
+	}
+	cmd := args[0]
+	args = args[1:]
+
+	if *baseURLStr == "" {
+		exUsage("--base-url must be specified")
+	}
+
+	baseURL, err := url.Parse(*baseURLStr)
+	if err != nil {
+		exUsage(fmt.Sprintf("invalid --base-url: %s: %s", *baseURLStr, err))
+	}
+	if baseURL.Scheme == "" || baseURL.Host == "" {
+		exUsage("invalid --base-url: " + *baseURLStr)
+	}
+	ctl := namerd.NewHttpController(baseURL, &http.Client{})
+
+	getDtabName := func() string {
+		name := args[0]
+		if name == "" {
+			exUsage("empty dtab name")
+		}
+		return name
+	}
+	switch cmd {
+	case "list":
+		if len(args) != 0 {
+			exUsage("list does not accept arguments")
+		}
+		names, err := ctl.List()
+		dieIf(err)
+		fmt.Println(strings.Join(names, "\n"))
+
+	case "get":
+		if len(args) != 1 {
+			exUsage("get <name>")
+		}
+		name := getDtabName()
+		rsp, err := ctl.Get(name)
+		dieIf(err)
+		fmt.Println(strings.Join(strings.SplitAfter(string(rsp.Dtab), ";"), "\n"))
+
+	case "new":
+		if len(args) != 2 {
+			exUsage(fmt.Sprintf("%s <name> <file>", cmd))
+		}
+		name := getDtabName()
+		dtab := readDtabPath(args[1])
+		_, err := ctl.Create(name, dtab)
+		dieIf(err)
+
+	case "update":
+		if len(args) != 2 {
+			exUsage(fmt.Sprintf("%s <name> <file>", cmd))
+		}
+		name := getDtabName()
+		dtab := readDtabPath(args[1])
+		v, err := ctl.Get(name)
+		dieIf(err)
+		_, err = ctl.Update(name, dtab, v.Version)
+		dieIf(err)
+
+	default:
+		exUsage("unexpected command: " + cmd)
+	}
+}
+
+func dieIf(err error) {
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
+	}
+}
+
+func readDtabPath(path string) namerd.Dtab {
+	var file io.Reader
+	var err error
+	switch path {
+	case "":
+		exUsage("empty dtab path")
+	case "-":
+		file = os.Stdin
+	default:
+		file, err = os.Open(path)
+		dieIf(err)
+	}
+	dtab, err := ioutil.ReadAll(file)
+	dieIf(err)
+	return namerd.Dtab(dtab)
+}

--- a/namerd/controller.go
+++ b/namerd/controller.go
@@ -1,0 +1,156 @@
+package namerd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// XXX later we should add support for parsing dtabs
+
+type (
+	Dtab    string
+	Version string
+
+	VersionedDtab struct {
+		Version Version
+		Dtab    Dtab
+	}
+
+	Controller interface {
+		List() ([]string, error)
+		Get(name string) (*VersionedDtab, error)
+		Create(name string, dtab Dtab) (Version, error)
+		Update(name string, dtab Dtab, version Version) (Version, error)
+	}
+
+	httpController struct {
+		baseURL *url.URL
+		client  *http.Client
+	}
+)
+
+func NewHttpController(baseURL *url.URL, client *http.Client) Controller {
+	return &httpController{baseURL, client}
+}
+
+func (ctl *httpController) dtabRequest(method, name string, data io.Reader) (*http.Request, error) {
+	u := *ctl.baseURL
+	if name == "" {
+		u.Path = "/api/1/dtabs"
+	} else {
+		u.Path = fmt.Sprintf("/api/1/dtabs/%s", name)
+	}
+	return http.NewRequest(method, u.String(), data)
+}
+
+func (ctl *httpController) List() ([]string, error) {
+	req, err := ctl.dtabRequest("GET", "", nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+
+	rsp, err := ctl.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer drainAndClose(rsp)
+
+	switch rsp.StatusCode {
+	case http.StatusOK:
+		var names []string
+		if err := json.NewDecoder(rsp.Body).Decode(&names); err != nil {
+			return nil, err
+		}
+		return names, nil
+
+	default:
+		return nil, fmt.Errorf("unexpected response: %s", rsp.Status)
+	}
+}
+
+func (ctl *httpController) Get(name string) (*VersionedDtab, error) {
+	req, err := ctl.dtabRequest("GET", name, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/dtab")
+
+	rsp, err := ctl.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer drainAndClose(rsp)
+
+	switch rsp.StatusCode {
+	case http.StatusOK:
+		v := Version(rsp.Header.Get("ETag"))
+		bytes, err := ioutil.ReadAll(rsp.Body)
+		if err != nil {
+			return nil, err
+		}
+		return &VersionedDtab{v, Dtab(bytes)}, nil
+
+	default:
+		return nil, fmt.Errorf("unexpected response: %s", rsp.Status)
+	}
+}
+
+func (ctl *httpController) Create(name string, dtab Dtab) (Version, error) {
+	req, err := ctl.dtabRequest("POST", name, strings.NewReader(string(dtab)))
+	if err != nil {
+		return Version(""), err
+	}
+	req.Header.Set("Content-Type", "application/dtab")
+
+	rsp, err := ctl.client.Do(req)
+	if err != nil {
+		return Version(""), err
+	}
+	defer drainAndClose(rsp)
+
+	switch rsp.StatusCode {
+	case http.StatusOK, http.StatusCreated, http.StatusNoContent:
+		v := Version(rsp.Header.Get("ETag"))
+		return v, nil
+
+	default:
+		return Version(""), fmt.Errorf("unexpected response: %s", rsp.Status)
+	}
+}
+
+func (ctl *httpController) Update(name string, dtab Dtab, version Version) (Version, error) {
+	req, err := ctl.dtabRequest("PUT", name, strings.NewReader(string(dtab)))
+	if err != nil {
+		return Version(""), err
+	}
+	req.Header.Set("Content-Type", "application/dtab")
+	req.Header.Set("If-Match", string(version))
+
+	rsp, err := ctl.client.Do(req)
+	if err != nil {
+		return Version(""), err
+	}
+	defer drainAndClose(rsp)
+
+	switch rsp.StatusCode {
+	case http.StatusOK, http.StatusCreated, http.StatusNoContent:
+		v := Version(rsp.Header.Get("ETag"))
+		return v, nil
+
+	default:
+		return Version(""), fmt.Errorf("unexpected response: %s", rsp.Status)
+	}
+}
+
+func drainAndClose(resp *http.Response) {
+	if resp != nil {
+		io.Copy(ioutil.Discard, resp.Body)
+		resp.Body.Close()
+	}
+}


### PR DESCRIPTION
This is a namerd client utility that interacts with the namerd's httpController api.

It is not intended to be comprehensive or well-documented yet -- the main certainly needs some work.

It is in a separate repo so that it can easily be used as a library (i.e. in a GOPATH) without having to pull in all of linkerd.  It may make sense to merge later, but for now I feel like it's lighter weight to keep it separate. (Specifically given Go's dependency management and packaging).
